### PR TITLE
Fix get_sensor_number regex: multi-word sensors and unrecognised names

### DIFF
--- a/auxil/get_sensor_number.m
+++ b/auxil/get_sensor_number.m
@@ -31,15 +31,19 @@ function [main_sensor, sensor_number] = get_sensor_number(sensor_name)
 %
 % DATE: APRIL 16, 2025  (Version 1.1.0)
 
-% first case: main sensor does not contain numbers,
-% e.g. if sensor_name is 'DOXY' or 'DOXY2'
+% BSDOXY FIX: pristine v1.1.0 could not parse the underscore form 'DOXY_2'
+% (it expects 'DOXY2') and crashed on unknown sensors. Parse the base sensor
+% name + optional sensor number, handling DOXY, DOXY2, DOXY_2, BBP700, BBP700_2,
+% DOWNWELLING_PAR, PH_IN_SITU_TOTAL, ... and return empty for a genuinely
+% unrecognised name (initialize_sprof expects empty to flag it).
+%   main : [A-Z]+ , optional _LETTER groups (DOWNWELLING_PAR) , optional 3-digit
+%          wavelength (BBP700).   num : optional trailing 2..9, with or without '_'.
 match = regexp(sensor_name, ...
-    '(?<main>[A-Z]+(_[A-Z]+)?)_?(?<num>[2-9]?)$','names');
+    '^(?<main>[A-Z]+(_[A-Z]+)*(\d{3})?)(?<num>_?[2-9])?$', 'names');
 if isempty(match)
-    % second case: main sensor contains numbers, e.g., 'BBP700' or 'BBP700_2'
-    match = regexp(sensor_name, ...
-        '(?<main>[A-Z]+(_[A-Z]+)?\d{3})(?<num>_[2-9])?$','names');
-    match.num = strrep(match.num, '_', '');
+    main_sensor = '';
+    sensor_number = '';
+    return
 end
 main_sensor = match.main;
-sensor_number = match.num;
+sensor_number = strrep(match.num, '_', '');


### PR DESCRIPTION
Extends the 9a0536e regex fix (DOXY_2 parsing) further:
- main sensor group now allows unlimited underscore-separated words ((_[A-Z]+)? → *), fixing PH_IN_SITU_TOTAL, DOWNWELLING_PAR, UP_RADIANCE/DOWN_IRRADIANCE family names when a sensor-number suffix is present — the current regex only allows one extra word and mis-parses these.
- Folds the wavelength-suffix case (BBP700) inline instead of a second regex pass.
- Adds an isempty(match) guard: an unrecognised sensor name currently crashes on match.num against an empty struct in initialize_sprof.m's unknown-sensor path, instead of hitting the intended warning(...).
Validated against all 29 names in Settings.avail_vars (initialize_argo.m) plus the documented DOXY2/BBP700_2 suffix convention.